### PR TITLE
fix missing params in the additional volume task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,9 +98,11 @@
     module: cs_volume
     vm: "{{ cs_instance_name }}"
     name: "DATA-{{ cs_instance_name }}"
-    project: "{{ cs_project }}"
-    zone: "{{ cs_zone }}"
     disk_offering: "{{ cs_disk_offering }}"
     size: "{{ cs_disk_size }}"
+    project: "{{ cs_project }}"
+    domain: "{{ cs_domain }}"
+    zone: "{{ cs_zone }}"
+    api_region: "{{ cs_region }}"
     state: attached
   when: cs_disk


### PR DESCRIPTION
task did not work for other regions than the default one and for different domains