### PR TITLE
use item.vm for port-forwarding

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
   local_action:
     module: cs_portforward
     ip_address: "{{ item.public_ip | default(cs_public_ip) }}"
-    vm: "{{ cs_instance_name }}"
+    vm: "{{ item.vm | default(cs_instance_name) }}"
     public_port: "{{ item.public_port }}"
     private_port: "{{ item.private_port | default(item.public_port) }}"
     protocol: "{{ item.protocol | default('tcp') }}"


### PR DESCRIPTION
add port-forwarding to other destination then current host. Not possible
to move these rules to destination hosts config if this one is already
using static NAT with a different IP